### PR TITLE
fix:DeleteAction

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,5 @@
 
 ## 関連Issue
 
-- 関連Issue: close #
+- close #
+- close #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test test:system
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "jbuilder"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "tzinfo-data", platforms:  %i[mswin mingw x64_mingw jruby]
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
@@ -44,7 +44,7 @@ gem "thruster", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  gem "debug", platforms: %i[mri mswin mingw x64_mingw], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
@@ -73,7 +73,7 @@ gem "devise"
 gem "rails-i18n"
 
 # 環境変数設定
-gem "dotenv-rails"
+gem "dotenv-rails", groups: [ :development, :test ]
 # railsプロジェクトでOpenAI APIを使うgem
 gem "ruby-openai"
 # lintチェックツール

--- a/app/controllers/colors_controller.rb
+++ b/app/controllers/colors_controller.rb
@@ -12,7 +12,7 @@ class ColorsController < ApplicationController
   end
 
   def create
-    @color = Color.new(color_params)
+    @color = current_user.colors.build(color_params)
     if @color.save
       # /lib/にあるmoduleで色のマッピング
       mapped_color = ColorMapping.mapping_color(color_params[:color_name])
@@ -39,8 +39,8 @@ class ColorsController < ApplicationController
   end
 
   def destroy
-    @color.destroy!
-    redirect_to colors_path, notice: "削除成功", status: :see_other
+    current_user.colors.today_form.destroy_all
+    redirect_to new_color_path, notice: "データの削除成功", status: :see_other
   end
 
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,6 +3,5 @@ class ApplicationRecord < ActiveRecord::Base
 
   scope :today_form, -> { where(created_at: Time.current.beginning_of_day..Time.current.end_of_day)
   .order(created_at: :desc)
-  .limit(1)
 }
 end

--- a/app/views/colors/index.html.erb
+++ b/app/views/colors/index.html.erb
@@ -1,16 +1,14 @@
 <% if @color.present? %>
-    <div class="">
+    <div>
         <h2 class="">私が今日選択した色は:<%= ColorMapping.mapping_color(@color.color_name) %></h2>
         <div class="<%= ColorMapping.color_class(@color.color_name) %> rounded-full w-10 h-10 m-10"></div>
     </div>
-
     <%= render 'shared/response' %>
-
-
     <div class="ボタンエリア">
         <%= link_to "edit", edit_color_path(@color), class: "btn btn-ghost rounded-btn",data: {turbo: false}%>
         <%= link_to "delete", color_path(@color), class: "btn btn-ghost rounded-btn", data: { turbo_method: :delete, turbo_confirm:"Are you sure?" }  %>
     </div>
 <% else %>
     <h1>今日は気分の登録をされていません</h1>
+    <%= link_to "気分を登録する", new_color_path, class: "btn btn-primary" %>
 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+  require "dotenv"
+  Dotenv.load(".env.test")
 end

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -2,7 +2,7 @@ require "openai"
 
 # Rails全体で利用するOpenAIの設定を保存
 Rails.application.config.openai = {
-  api_key: ENV.fetch("OPENAI_API_KEY"),
+  api_key: ENV.fetch("OPENAI_API_KEY", "default_test_key"),
   default_model: "gpt-4o-mini"
 }
 # OpenAIライブラリの初期設定


### PR DESCRIPTION
## 概要
「見る」機能では、24時間以内にレコード登録をしたデータを降順に1件抽出して表示している。この時deleteを行う際、登録しているデータが１件以上あるとき、1つ前のレコードデータが自動で抽出される。
これはユーザーが意図してない気分の記録が表示されてしまうことになるため、deleteアクション時に「今日1日」のデータを全て削除するようにした。

なお、ユーザーが登録した際、登録できるデータを１件に絞るか、すでに登録されているデータがあれば、上書きするかどうかを確認する機能が必要であるため、MVPリリース後に検討する。
## 変更点

- @color.destroyでなくcurrent_user.colors.today_form.destroy_allで「１日分」のデータの削除を行う処理を追加
-
-


## 関連Issue

- 関連Issue: close #
