### PR TITLE
fix:GoogleLogin

### DIFF
--- a/app/javascript/link_google_account.js
+++ b/app/javascript/link_google_account.js
@@ -2,7 +2,7 @@ document.addEventListener("turbo:load", () => {
 
     const googleLink = document.getElementById("link-google-account");
     if (googleLink) {
-        googleLink.addEventListener("click", () => {
+        googleLink.addEventListener("click", async () => {
             const actionType = googleLink.dataset.actionType;
             const form = document.createElement("form");
             form.method = "POST";
@@ -25,18 +25,11 @@ document.addEventListener("turbo:load", () => {
             const left = window.screenX;
             const top = window.screenY;
 
-            window.open("", "popup",
-                        `"width=${width}, height=${height}", top=${top}, left=${left}, resizable=no, scrollbars=yes`
-                    );
-            // fetch("/users/link_google_account", {
-            //     method: "POST",
-            //     headers: {
-            //         "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').getAttribute("content")
-            //     }
-            //     });
+            window.open("", "popup",`"width=${width}, height=${height}", top=${top}, left=${left}`);
+
             form.submit();
             // 送信後フォームを削除（クリーンアップ）
             document.body.removeChild(form);
-        })
+         })
     };
 });

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,7 +14,7 @@
             <div class="mt-6 text-center text-md font-bold ">
               連携を解除してもデータは削除されません。
             </div>
-   <% else %>
+    <% else %>
     <%# 連携されてないデフォルトのUI %>
     <h1 class="sm:text-2xl text-xl font-bold text-center">ログイン</h1>
 <%= form_with model: @user, url: user_session_path, local: true, class: "space-y-4" do |f| %>

--- a/app/views/shared/_oauth_form.html.erb
+++ b/app/views/shared/_oauth_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: user_google_oauth2_omniauth_authorize_path(type: "login"), method: :post, data: { turbo: false },class: "space-y-4" do %>
+<%= form_with url: user_google_oauth2_omniauth_authorize_path(type: "login", prompt: "none"), method: :post, data: { turbo: false },class: "space-y-4" do %>
   <%= hidden_field_tag :type, "login" %>
 <button class="gsi-material-button block mx-auto" style="width:400px">
   <div class="gsi-material-button-state"></div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,7 +15,6 @@
         <p class="text-base-content text-opacity-70">
             <%= current_user.email %>
             <%= current_user.prefecture %>
-
         </p>
         <div class="card-actions">
             <%= link_to "Eメールを編集する", edit_user_path, class: "text-base-content btn bg-white w-full", data: { turbo_stream: true } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Rails.application.routes.draw do
     get "users/registration/edit_city", to: "users/registrations#edit_city", as: :edit_city
     delete "/users/unlink_google_account", to: "users/omniauth_callbacks#unlink_google_account", as: :unlink_google_account
   end
-
   resource :users, only: [ :show, :edit, :destroy, :update ] do
     get "profile", to: "users#show", as: "profile"
   end


### PR DESCRIPTION
## 概要
Googleログイン機能の実装を行いました
アカウント連携ボタンを設置し、連携させるとprovider uidの値を取得しユーザーのカラムに保存。
連携しカラムに値を持っているユーザーであることを判別しUIを切り替えボタンクリックのみでログインできる仕様です。

## 変更点

-
-
-


## 関連Issue

- close #
- close #
